### PR TITLE
単体テストの追加とClose時の例外を抑止。

### DIFF
--- a/TestSimplePipe/TestSimplePipe.cpp
+++ b/TestSimplePipe/TestSimplePipe.cpp
@@ -1,206 +1,444 @@
 ﻿#include "pch.h"
 #include <windows.h>
 #include <string>
+#include <sstream>
 #include <memory>
 #include <numeric>
 #include <algorithm>
 #include <memory.h>
+#include <ppl.h>
+#include <ppltasks.h>
 #include "CppUnitTest.h"
 #include "../inc/SimpleNamedPipe.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
-namespace abt::comm::simple_pipe::test::receiver
+namespace abt::comm::simple_pipe::test
 {
     using namespace abt::comm::simple_pipe;
 
-    //テスト用のパケットヘルパー共用体
-    template<size_t N>
-    union TestPacket {
-        struct {
-            alignas(4) DWORD size;
-            WCHAR data[N];
-        };
-        Packet p;
-    };
-
-    //テスト用パケット生成ヘルパー
-    template<size_t N>
-    TestPacket<N> CreatePacket(const std::wstring msg)
-    {
-        if (msg.size() != N) {
-            throw std::length_error("unmatch size");
-        }
-        TestPacket<N> p;
-        p.size = static_cast<DWORD>( (N * sizeof(WCHAR)) + sizeof(Packet::size));
-        std::copy(msg.begin(), msg.end(), p.data);
-        return p;
-    }
-
-    //パケットからメッセージの取り出し
-    std::wstring UnpackMsg(LPCVOID p, size_t s)
-    {
-        return std::wstring(reinterpret_cast<LPCWSTR>(p), 0, s / sizeof(WCHAR));
-    }
-
     //abt::comm::simple_pipe::Receiverテストクラス
-    TEST_CLASS(TestReceiver)
+    TEST_CLASS(TestSimplePipe)
     {
     public:
-
-        //1受信バッファーに1つのパケット
-        TEST_METHOD(SinglePacket)
+        TEST_METHOD(Constants)
         {
-            std::wstring expected = L"ABCDE";
-            auto testPacket = CreatePacket<5>(expected);
-            std::wstring actual;
-            Receiver receiver(1024, [&](const auto p, auto s) {
-                actual = UnpackMsg(p, s);
-            });
-            receiver.Feed(&testPacket, 14);
+            Assert::AreEqual(TypicalSimpleNamedPipeServer::BUFFER_SIZE, TYPICAL_BUFFER_SIZE);
+            Assert::AreEqual(TypicalSimpleNamedPipeServer::MAX_DATA_SIZE, TYPICAL_BUFFER_SIZE - static_cast<DWORD>(sizeof DWORD));
 
-            Assert::AreEqual(expected, actual);
+            Assert::AreEqual(TypicalSimpleNamedPipeClient::BUFFER_SIZE, TYPICAL_BUFFER_SIZE);
+            Assert::AreEqual(TypicalSimpleNamedPipeClient::MAX_DATA_SIZE, TYPICAL_BUFFER_SIZE - static_cast<DWORD>(sizeof DWORD));
         }
 
-        //1受信バッファーに5つのパケット
-        TEST_METHOD(MultiPacket)
+        TEST_METHOD(HelloEcho)
         {
-            TestPacket<5> testPackets[] = {
-                CreatePacket<5>(L"ABCDE"),
-                CreatePacket<5>(L"FGHIJ"),
-                CreatePacket<5>(L"KLMNO"),
-                CreatePacket<5>(L"PRSTU"),
-                CreatePacket<5>(L"VWXYZ"),
-            };
-            std::vector<std::wstring> expectedValues;
-            size_t totalSize = testPackets[0].size * _countof(testPackets);
-            std::unique_ptr<BYTE[]> buffer = std::make_unique<BYTE[]>(totalSize);
-            BYTE* dst = buffer.get();
-            for (const auto& p : testPackets) {
-                auto len = p.size;
-                memcpy(dst, &p, len);
-                dst += len;
-                expectedValues.emplace_back(std::wstring(p.data, 0, _countof(p.data)));
+            auto pipeName = std::wstring(L"\\\\.\\pipe\\") + winrt::to_hstring(winrt::Windows::Foundation::GuidHelper::CreateNewGuid());
+
+            concurrency::task<void> serverErrTask = concurrency::task_from_result();
+            concurrency::event closedEvent;
+            
+            TypicalSimpleNamedPipeServer server(pipeName.c_str(), nullptr, [&](auto& ps, const auto& param) {
+                switch (param.type) {
+                case PipeEventType::CONNECTED:
+                    break;
+                case PipeEventType::DISCONNECTED:
+                    closedEvent.set();
+                    break;
+                case PipeEventType::RECEIVED:
+                {
+                    std::wstring m(reinterpret_cast<LPCWSTR>(param.readBuffer), 0, param.readedSize / sizeof(WCHAR));
+                    std::wostringstream oss;
+                    oss << L"echo: " << m;
+                    std::wstring echoMessage = oss.str();
+                    ps.WriteAsync(&echoMessage[0], echoMessage.size() * sizeof(WCHAR)).wait();
+                }
+                break;
+                case PipeEventType::EXCEPTION:
+                    //監視タスクで例外発生
+                    if (param.errTask) {
+                        serverErrTask = param.errTask.value();
+                    }
+                    break;
+                }
+            });
+
+            concurrency::task<void> clientErrTask = concurrency::task_from_result();
+            concurrency::event echoComplete;
+            std::wstring echoMessage;
+
+            TypicalSimpleNamedPipeClient client(pipeName.c_str(), [&](auto& ps, const auto& param) {
+                switch (param.type) {
+                case PipeEventType::DISCONNECTED:
+                    break;
+                case PipeEventType::RECEIVED:
+                {
+                    std::wstring m(reinterpret_cast<LPCWSTR>(param.readBuffer), 0, param.readedSize / sizeof(WCHAR));
+                    echoMessage = m;
+                    echoComplete.set();
+                }
+                break;
+                case PipeEventType::EXCEPTION:
+                    //監視タスクで例外発生
+                    if (param.errTask) {
+                        clientErrTask = param.errTask.value();
+                    }
+                    break;
+                }
+            });
+
+            WCHAR hello[] = L"HELLO WORLD!";
+
+            client.WriteAsync(&hello[0], sizeof(hello)).wait();
+
+            if (concurrency::COOPERATIVE_TIMEOUT_INFINITE == echoComplete.wait(1000)) {
+                Assert::Fail();
             }
 
-            std::vector<std::wstring> actualValues;
-            Receiver receiver(1024, [&](const auto p, auto s) {
-                actualValues.emplace_back(UnpackMsg(p, s));
+            client.Close();
+            if (concurrency::COOPERATIVE_TIMEOUT_INFINITE == closedEvent.wait(1000)) {
+                Assert::Fail();
+            }
+            server.Close();
+
+            serverErrTask.wait();
+            clientErrTask.wait();
+
+            Assert::AreEqual(std::wstring(L"echo: HELLO WORLD!"), echoMessage);
+        }
+
+        TEST_METHOD(Hello1000times)
+        {
+            auto pipeName = std::wstring(L"\\\\.\\pipe\\") + winrt::to_hstring(winrt::Windows::Foundation::GuidHelper::CreateNewGuid());
+
+            concurrency::task<void> serverErrTask = concurrency::task_from_result();
+            concurrency::event closedEvent;
+
+            TypicalSimpleNamedPipeServer server(pipeName.c_str(), nullptr, [&](auto& ps, const auto& param) {
+                switch (param.type) {
+                case PipeEventType::CONNECTED:
+                    break;
+                case PipeEventType::DISCONNECTED:
+                    closedEvent.set();
+                    break;
+                case PipeEventType::RECEIVED:
+                {
+                    std::wstring m(reinterpret_cast<LPCWSTR>(param.readBuffer), 0, param.readedSize / sizeof(WCHAR));
+                    std::wostringstream oss;
+                    oss << L"echo: " << m;
+                    std::wstring echoMessage = oss.str();
+                    ps.WriteAsync(&echoMessage[0], echoMessage.size() * sizeof(WCHAR)).wait();
+                }
+                break;
+                case PipeEventType::EXCEPTION:
+                    //監視タスクで例外発生
+                    if (param.errTask) {
+                        serverErrTask = param.errTask.value();
+                    }
+                    break;
+                }
             });
-            receiver.Feed(buffer.get(), totalSize);
+
+            constexpr ULONG REPEAT = 1000;
+            auto remain = REPEAT;
+
+            std::vector<std::wstring> actualValues;
+            concurrency::task<void> clientErrTask = concurrency::task_from_result();
+            concurrency::event echoComplete;
+
+            TypicalSimpleNamedPipeClient client(pipeName.c_str(), [&](auto& ps, const auto& param) {
+                switch (param.type) {
+                case PipeEventType::DISCONNECTED:
+                    break;
+                case PipeEventType::RECEIVED:
+                {
+                    std::wstring m(reinterpret_cast<LPCWSTR>(param.readBuffer), 0, param.readedSize / sizeof(WCHAR));
+                    actualValues.emplace_back(m);
+                    if (0 == InterlockedDecrement(&remain)) {
+                        echoComplete.set();
+                    }
+                }
+                break;
+                case PipeEventType::EXCEPTION:
+                    //監視タスクで例外発生
+                    if (param.errTask) {
+                        clientErrTask = param.errTask.value();
+                    }
+                    break;
+                }
+            });
+
+
+            std::vector<std::wstring> expectedValues;
+            for (int i = 0; i < REPEAT; ++i) {
+                std::wstringstream oss;
+                oss << L"HELLO WORLD![" << i << "]";
+                auto message = oss.str();
+                expectedValues.emplace_back(std::wstring(L"echo: ") + message);
+
+                client.WriteAsync(&message[0], message.size() * sizeof(WCHAR));
+
+            }
+
+            if (concurrency::COOPERATIVE_TIMEOUT_INFINITE == echoComplete.wait(1000)) {
+                Assert::Fail();
+            }
+
+            client.Close();
+            if (concurrency::COOPERATIVE_TIMEOUT_INFINITE == closedEvent.wait(1000)) {
+                Assert::Fail();
+            }
+            server.Close();
+
+            serverErrTask.wait();
+            clientErrTask.wait();
 
             Assert::IsTrue(std::equal(expectedValues.begin(), expectedValues.end(), actualValues.begin(), actualValues.end()));
         }
 
-        //5つの受信バッファーに1つのパケット
-        TEST_METHOD(FragmentPacket)
+        TEST_METHOD(Connect1000times)
         {
-            auto packet = CreatePacket<15>(L"ABCDEFGHIJKLMNO");
+            auto pipeName = std::wstring(L"\\\\.\\pipe\\") + winrt::to_hstring(winrt::Windows::Foundation::GuidHelper::CreateNewGuid());
 
-            std::vector<BYTE> buffer;
-            std::wstring actual;
-            Receiver receiver(1024, [&](const auto p, auto s) {
-                actual = std::wstring(reinterpret_cast<LPCWSTR>(p), 0, s / sizeof(WCHAR));
+            concurrency::task<void> serverErrTask = concurrency::task_from_result();
+            concurrency::event closedEvent;
+
+            TypicalSimpleNamedPipeServer server(pipeName.c_str(), nullptr, [&](auto& ps, const auto& param) {
+                switch (param.type) {
+                case PipeEventType::CONNECTED:
+                    break;
+                case PipeEventType::DISCONNECTED:
+                    closedEvent.set();
+                    break;
+                case PipeEventType::RECEIVED:
+                {
+                    std::wstring m(reinterpret_cast<LPCWSTR>(param.readBuffer), 0, param.readedSize / sizeof(WCHAR));
+                    std::wostringstream oss;
+                    oss << L"echo: " << m;
+                    std::wstring echoMessage = oss.str();
+                    ps.WriteAsync(&echoMessage[0], echoMessage.size() * sizeof(WCHAR)).wait();
+                }
+                break;
+                case PipeEventType::EXCEPTION:
+                    //監視タスクで例外発生
+                    if (param.errTask) {
+                        serverErrTask = param.errTask.value();
+                    }
+                    break;
+                }
             });
 
-            auto remain = packet.size;
-            const BYTE* p = reinterpret_cast<const BYTE*>(&packet);
-            constexpr DWORD fragmentSize = 8;
-            while (remain > 0) {
-                auto size = (std::min)(fragmentSize, remain);
-                receiver.Feed(p, size);
-                p += size;
-                remain -= size;
-            }
-            Assert::IsTrue(std::equal(std::begin(packet.data), std::end(packet.data), actual.begin(), actual.end()));
-        }
-
-        //2つの受信バッファーの境界をまたぐ形で2つ目パケットが存在する
-        TEST_METHOD(SplitHeaderPacket)
-        {
-            auto packet1 = CreatePacket<5>(L"ABCDE");
-            auto packet2 = CreatePacket<5>(L"FGHIJ");
-
-            auto expected = std::vector<std::wstring>{
-                std::wstring(std::begin(packet1.data), std::end(packet1.data)),
-                std::wstring(std::begin(packet2.data), std::end(packet2.data)),
-            };
-
-
-            auto totalSize = packet1.size + packet2.size;
-            auto buffer = std::make_unique<BYTE[]>(totalSize);
-            memcpy(&buffer[0], &packet1.p, packet1.size);
-            memcpy(&buffer[packet1.size], &packet2.p, packet2.size);
-
-            std::vector<std::wstring> acutals;
-            Receiver receiver(1024, [&](const auto p, auto s){
-                acutals.emplace_back(std::wstring(reinterpret_cast<LPCWSTR>(p), 0, s / sizeof(WCHAR)));
-            });
-
-            const BYTE* p = &buffer[0];
-            DWORD remain = totalSize;
-            receiver.Feed(p, 16); p += 16; remain -= 16;
-            receiver.Feed(p, 1);  p += 1; remain -= 1;
-            receiver.Feed(p, remain);
-
-            Assert::IsTrue(std::equal(expected.begin(), expected.end(), acutals.begin(), acutals.end()));
-        }
-
-        //Receiverのステータス全パターンを網羅するテスト
-        TEST_METHOD(ComplexPackets)
-        {
-            auto packet1 = CreatePacket<5>(L"ABCDE");
-            auto packet2 = CreatePacket<10>(L"FGHIJKLMNO");
-            auto packet3 = CreatePacket<2>(L"PQ");
-            auto packet4 = CreatePacket<2>(L"RS");
-            auto packet5 = CreatePacket<7>(L"TUVWXYZ");
-
-            auto expected = std::vector<std::wstring>{
-                std::wstring(std::begin(packet1.data), std::end(packet1.data)),
-                std::wstring(std::begin(packet2.data), std::end(packet2.data)),
-                std::wstring(std::begin(packet3.data), std::end(packet3.data)),
-                std::wstring(std::begin(packet4.data), std::end(packet4.data)),
-                std::wstring(std::begin(packet5.data), std::end(packet5.data)),
-            };
+            concurrency::task<void> clientErrTask = concurrency::task_from_result();
+            concurrency::event echoComplete;
+            std::wstring echoMessage;
+            for (auto i = 0; i < 1000; ++i) {
+                TypicalSimpleNamedPipeClient client(pipeName.c_str(), [&](auto& ps, const auto& param) {
+                    switch (param.type) {
+                    case PipeEventType::DISCONNECTED:
+                        break;
+                    case PipeEventType::RECEIVED:
+                    {
+                        std::wstring m(reinterpret_cast<LPCWSTR>(param.readBuffer), 0, param.readedSize / sizeof(WCHAR));
+                        echoMessage = m;
+                        echoComplete.set();
+                    }
+                    break;
+                    case PipeEventType::EXCEPTION:
+                        //監視タスクで例外発生
+                        if (param.errTask) {
+                            clientErrTask = param.errTask.value();
+                        }
+                        break;
+                    }
+                });
 
 
-            auto totalSize = packet1.size + packet2.size + packet3.size + packet4.size + packet5.size;
-            auto buffer = std::make_unique<BYTE[]>(totalSize);
-            auto p = &buffer[0];
-            memcpy(p, &packet1.p, packet1.size); p += packet1.size;
-            memcpy(p, &packet2.p, packet2.size); p += packet2.size;
-            memcpy(p, &packet3.p, packet3.size); p += packet3.size;
-            memcpy(p, &packet4.p, packet4.size); p += packet4.size;
-            memcpy(p, &packet5.p, packet5.size);
+                std::wstringstream oss;
+                oss << L"HELLO WORLD![" << i << "]";
+                auto message = oss.str();
 
-            std::vector<std::wstring> acutals;
-            Receiver receiver(1024, [&](const auto p, auto s) {
-                acutals.emplace_back(std::wstring(reinterpret_cast<LPCWSTR>(p), 0, s / sizeof(WCHAR)));
-            });
+                client.WriteAsync(&message[0], message.size() * sizeof(WCHAR)).wait();
 
-            constexpr DWORD FEED_SIZE = 16;
-            auto remain = static_cast<DWORD>(totalSize);
-            p = &buffer[0];
-            while (remain > 0) {
-                auto size = (std::min)(remain, FEED_SIZE);
-                receiver.Feed(p, size);
-                remain -= size;
-                p += size;
+                if (concurrency::COOPERATIVE_TIMEOUT_INFINITE == echoComplete.wait(1000)) {
+                    Assert::Fail();
+                }
+
+                client.Close();
+                if (concurrency::COOPERATIVE_TIMEOUT_INFINITE == closedEvent.wait(1000)) {
+                    Assert::Fail();
+                }
+                try {
+                    serverErrTask.wait();
+                    clientErrTask.wait();
+                }
+                catch (winrt::hresult_error& ex)
+                {
+                    Assert::Fail(ex.message().c_str());
+                }
+                catch (std::exception& ex)
+                {
+                    Assert::Fail(winrt::to_hstring(ex.what()).c_str());
+                }
+                Assert::AreEqual(std::wstring(L"echo: ") + message, echoMessage);
+
+                echoComplete.reset();
+                closedEvent.reset();
             }
 
-            Assert::IsTrue(std::equal(expected.begin(), expected.end(), acutals.begin(), acutals.end()));
+            server.Close();
         }
 
-        //バッファーサイズが上限より大きい場合に例外
-        TEST_METHOD(TooLongPacket)
+        TEST_METHOD(DiconnectByServer)
         {
-            auto packet = CreatePacket<10>(L"FGHIJKLMNO");
-            Receiver receiver(4, [&](const auto p, auto s) {
+            auto pipeName = std::wstring(L"\\\\.\\pipe\\") + winrt::to_hstring(winrt::Windows::Foundation::GuidHelper::CreateNewGuid());
+
+            concurrency::task<void> serverErrTask = concurrency::task_from_result();
+            concurrency::event closedEvent;
+
+            TypicalSimpleNamedPipeServer server(pipeName.c_str(), nullptr, [&](auto& ps, const auto& param) {
+                switch (param.type) {
+                case PipeEventType::CONNECTED:
+                    break;
+                case PipeEventType::DISCONNECTED:
+                    closedEvent.set();
+                    break;
+                case PipeEventType::RECEIVED:
+                {
+                    std::wstring m(reinterpret_cast<LPCWSTR>(param.readBuffer), 0, param.readedSize / sizeof(WCHAR));
+                    std::wostringstream oss;
+                    oss << L"echo: " << m;
+                    std::wstring echoMessage = oss.str();
+                    ps.WriteAsync(&echoMessage[0], echoMessage.size() * sizeof(WCHAR)).wait();
+                    ps.Close();
+                }
+                break;
+                case PipeEventType::EXCEPTION:
+                    //監視タスクで例外発生
+                    if (param.errTask) {
+                        serverErrTask = param.errTask.value();
+                    }
+                    break;
+                }
+            });
+
+            concurrency::task<void> clientErrTask = concurrency::task_from_result();
+            concurrency::event echoComplete;
+            std::wstring echoMessage;
+
+            TypicalSimpleNamedPipeClient client(pipeName.c_str(), [&](auto& ps, const auto& param) {
+                switch (param.type) {
+                case PipeEventType::DISCONNECTED:
+                    break;
+                case PipeEventType::RECEIVED:
+                {
+                    std::wstring m(reinterpret_cast<LPCWSTR>(param.readBuffer), 0, param.readedSize / sizeof(WCHAR));
+                    echoMessage = m;
+                    echoComplete.set();
+                }
+                break;
+                case PipeEventType::EXCEPTION:
+                    //監視タスクで例外発生
+                    if (param.errTask) {
+                        clientErrTask = param.errTask.value();
+                    }
+                    break;
+                }
+            });
+
+            WCHAR hello[] = L"HELLO WORLD!";
+
+            client.WriteAsync(&hello[0], sizeof(hello)).wait();
+
+            if (concurrency::COOPERATIVE_TIMEOUT_INFINITE == echoComplete.wait(1000)) {
                 Assert::Fail();
-            });
+            }
 
-            Assert::ExpectException<std::length_error>([&]() {receiver.Feed(&packet, packet.size); });
+            if (concurrency::COOPERATIVE_TIMEOUT_INFINITE == closedEvent.wait(1000)) {
+                Assert::Fail();
+            }
+            server.Close();
+
+            serverErrTask.wait();
+            clientErrTask.wait();
+
+            Assert::AreEqual(std::wstring(L"echo: HELLO WORLD!"), echoMessage);
         }
 
+        TEST_METHOD(WriteCancel)
+        {
+            auto pipeName = std::wstring(L"\\\\.\\pipe\\") + winrt::to_hstring(winrt::Windows::Foundation::GuidHelper::CreateNewGuid());
+
+            concurrency::task<void> serverErrTask = concurrency::task_from_result();
+            concurrency::event closedEvent;
+
+            TypicalSimpleNamedPipeServer server(pipeName.c_str(), nullptr, [&](auto& ps, const auto& param) {
+                switch (param.type) {
+                case PipeEventType::CONNECTED:
+                    break;
+                case PipeEventType::DISCONNECTED:
+                    closedEvent.set();
+                    break;
+                case PipeEventType::RECEIVED:
+                {
+                    std::wstring m(reinterpret_cast<LPCWSTR>(param.readBuffer), 0, param.readedSize / sizeof(WCHAR));
+                    std::wostringstream oss;
+                    oss << L"echo: " << m;
+                    std::wstring echoMessage = oss.str();
+                    ps.WriteAsync(&echoMessage[0], echoMessage.size() * sizeof(WCHAR)).wait();
+                }
+                break;
+                case PipeEventType::EXCEPTION:
+                    //監視タスクで例外発生
+                    if (param.errTask) {
+                        serverErrTask = param.errTask.value();
+                    }
+                    break;
+                }
+            });
+
+            concurrency::task<void> clientErrTask = concurrency::task_from_result();
+            concurrency::event echoComplete;
+            std::wstring echoMessage;
+
+            TypicalSimpleNamedPipeClient client(pipeName.c_str(), [&](auto& ps, const auto& param) {
+                switch (param.type) {
+                case PipeEventType::DISCONNECTED:
+                    break;
+                case PipeEventType::RECEIVED:
+                {
+                    std::wstring m(reinterpret_cast<LPCWSTR>(param.readBuffer), 0, param.readedSize / sizeof(WCHAR));
+                    echoMessage = m;
+                    echoComplete.set();
+                }
+                break;
+                case PipeEventType::EXCEPTION:
+                    //監視タスクで例外発生
+                    if (param.errTask) {
+                        clientErrTask = param.errTask.value();
+                    }
+                    break;
+                }
+            });
+
+            WCHAR hello[] = L"HELLO WORLD!";
+
+            auto cts = concurrency::cancellation_token_source();
+            cts.cancel();
+            Assert::ExpectException<concurrency::task_canceled>([&]() {
+                client.WriteAsync(&hello[0], sizeof(hello), cts.get_token());
+            });
+
+            if (concurrency::COOPERATIVE_TIMEOUT_INFINITE == echoComplete.wait(1000)) {
+                Assert::Fail();
+            }
+
+            client.Close();
+            if (concurrency::COOPERATIVE_TIMEOUT_INFINITE == closedEvent.wait(1000)) {
+                Assert::Fail();
+            }
+            server.Close();
+
+            serverErrTask.wait();
+            clientErrTask.wait();
+        }
     };
 }

--- a/TestSimplePipe/TestSimplePipe.cpp
+++ b/TestSimplePipe/TestSimplePipe.cpp
@@ -106,7 +106,7 @@ namespace abt::comm::simple_pipe::test
             Assert::AreEqual(std::wstring(L"echo: HELLO WORLD!"), echoMessage);
         }
 
-        TEST_METHOD(Hello1000times)
+        void HelloNtimes(const ULONG repeat)
         {
             auto pipeName = std::wstring(L"\\\\.\\pipe\\") + winrt::to_hstring(winrt::Windows::Foundation::GuidHelper::CreateNewGuid());
 
@@ -138,8 +138,7 @@ namespace abt::comm::simple_pipe::test
                 }
             });
 
-            constexpr ULONG REPEAT = 1000;
-            auto remain = REPEAT;
+            auto remain = repeat;
 
             std::vector<std::wstring> actualValues;
             concurrency::task<void> clientErrTask = concurrency::task_from_result();
@@ -169,7 +168,7 @@ namespace abt::comm::simple_pipe::test
 
 
             std::vector<std::wstring> expectedValues;
-            for (int i = 0; i < REPEAT; ++i) {
+            for (int i = 0; i < repeat; ++i) {
                 std::wstringstream oss;
                 oss << L"HELLO WORLD![" << i << "]";
                 auto message = oss.str();
@@ -195,7 +194,20 @@ namespace abt::comm::simple_pipe::test
             Assert::IsTrue(std::equal(expectedValues.begin(), expectedValues.end(), actualValues.begin(), actualValues.end()));
         }
 
-        TEST_METHOD(Connect1000times)
+        BEGIN_TEST_METHOD_ATTRIBUTE(Hello1000times)
+            TEST_PRIORITY(2)
+        END_TEST_METHOD_ATTRIBUTE()
+        TEST_METHOD(Hello1000times)
+        {
+            HelloNtimes(1000);
+        }
+
+        TEST_METHOD(Hello3times)
+        {
+            HelloNtimes(3);
+        }
+
+        void ConnectNtimes(const ULONG repeat)
         {
             auto pipeName = std::wstring(L"\\\\.\\pipe\\") + winrt::to_hstring(winrt::Windows::Foundation::GuidHelper::CreateNewGuid());
 
@@ -230,7 +242,7 @@ namespace abt::comm::simple_pipe::test
             concurrency::task<void> clientErrTask = concurrency::task_from_result();
             concurrency::event echoComplete;
             std::wstring echoMessage;
-            for (auto i = 0; i < 1000; ++i) {
+            for (auto i = 0; i < repeat; ++i) {
                 TypicalSimpleNamedPipeClient client(pipeName.c_str(), [&](auto& ps, const auto& param) {
                     switch (param.type) {
                     case PipeEventType::DISCONNECTED:
@@ -285,6 +297,19 @@ namespace abt::comm::simple_pipe::test
             }
 
             server.Close();
+        }
+
+        BEGIN_TEST_METHOD_ATTRIBUTE(Connect1000times)
+            TEST_PRIORITY(2)
+        END_TEST_METHOD_ATTRIBUTE()
+        TEST_METHOD(Connect1000times)
+        {
+            ConnectNtimes(1000);
+        }
+
+        TEST_METHOD(Connect3times)
+        {
+            ConnectNtimes(3);
         }
 
         TEST_METHOD(DiconnectByServer)

--- a/TestSimplePipe/TestSimplePipe.vcxproj
+++ b/TestSimplePipe/TestSimplePipe.vcxproj
@@ -167,6 +167,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="TestSimplePipe.cpp" />
+    <ClCompile Include="TestSimplePipeReceiver.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/TestSimplePipe/TestSimplePipe.vcxproj.filters
+++ b/TestSimplePipe/TestSimplePipe.vcxproj.filters
@@ -21,6 +21,9 @@
     <ClCompile Include="pch.cpp">
       <Filter>ソース ファイル</Filter>
     </ClCompile>
+    <ClCompile Include="TestSimplePipeReceiver.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">

--- a/TestSimplePipe/TestSimplePipeReceiver.cpp
+++ b/TestSimplePipe/TestSimplePipeReceiver.cpp
@@ -1,0 +1,206 @@
+﻿#include "pch.h"
+#include <windows.h>
+#include <string>
+#include <memory>
+#include <numeric>
+#include <algorithm>
+#include <memory.h>
+#include "CppUnitTest.h"
+#include "../inc/SimpleNamedPipe.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace abt::comm::simple_pipe::test::receiver
+{
+    using namespace abt::comm::simple_pipe;
+
+    //テスト用のパケットヘルパー共用体
+    template<size_t N>
+    union TestPacket {
+        struct {
+            alignas(4) DWORD size;
+            WCHAR data[N];
+        };
+        Packet p;
+    };
+
+    //テスト用パケット生成ヘルパー
+    template<size_t N>
+    TestPacket<N> CreatePacket(const std::wstring msg)
+    {
+        if (msg.size() != N) {
+            throw std::length_error("unmatch size");
+        }
+        TestPacket<N> p;
+        p.size = static_cast<DWORD>((N * sizeof(WCHAR)) + sizeof(Packet::size));
+        std::copy(msg.begin(), msg.end(), p.data);
+        return p;
+    }
+
+    //パケットからメッセージの取り出し
+    std::wstring UnpackMsg(LPCVOID p, size_t s)
+    {
+        return std::wstring(reinterpret_cast<LPCWSTR>(p), 0, s / sizeof(WCHAR));
+    }
+
+    //abt::comm::simple_pipe::Receiverテストクラス
+    TEST_CLASS(TestReceiver)
+    {
+    public:
+
+        //1受信バッファーに1つのパケット
+        TEST_METHOD(SinglePacket)
+        {
+            std::wstring expected = L"ABCDE";
+            auto testPacket = CreatePacket<5>(expected);
+            std::wstring actual;
+            Receiver receiver(1024, [&](const auto p, auto s) {
+                actual = UnpackMsg(p, s);
+            });
+            receiver.Feed(&testPacket, 14);
+
+            Assert::AreEqual(expected, actual);
+        }
+
+        //1受信バッファーに5つのパケット
+        TEST_METHOD(MultiPacket)
+        {
+            TestPacket<5> testPackets[] = {
+                CreatePacket<5>(L"ABCDE"),
+                CreatePacket<5>(L"FGHIJ"),
+                CreatePacket<5>(L"KLMNO"),
+                CreatePacket<5>(L"PRSTU"),
+                CreatePacket<5>(L"VWXYZ"),
+            };
+            std::vector<std::wstring> expectedValues;
+            size_t totalSize = testPackets[0].size * _countof(testPackets);
+            std::unique_ptr<BYTE[]> buffer = std::make_unique<BYTE[]>(totalSize);
+            BYTE* dst = buffer.get();
+            for (const auto& p : testPackets) {
+                auto len = p.size;
+                memcpy(dst, &p, len);
+                dst += len;
+                expectedValues.emplace_back(std::wstring(p.data, 0, _countof(p.data)));
+            }
+
+            std::vector<std::wstring> actualValues;
+            Receiver receiver(1024, [&](const auto p, auto s) {
+                actualValues.emplace_back(UnpackMsg(p, s));
+            });
+            receiver.Feed(buffer.get(), totalSize);
+
+            Assert::IsTrue(std::equal(expectedValues.begin(), expectedValues.end(), actualValues.begin(), actualValues.end()));
+        }
+
+        //5つの受信バッファーに1つのパケット
+        TEST_METHOD(FragmentPacket)
+        {
+            auto packet = CreatePacket<15>(L"ABCDEFGHIJKLMNO");
+
+            std::vector<BYTE> buffer;
+            std::wstring actual;
+            Receiver receiver(1024, [&](const auto p, auto s) {
+                actual = std::wstring(reinterpret_cast<LPCWSTR>(p), 0, s / sizeof(WCHAR));
+            });
+
+            auto remain = packet.size;
+            const BYTE* p = reinterpret_cast<const BYTE*>(&packet);
+            constexpr DWORD fragmentSize = 8;
+            while (remain > 0) {
+                auto size = (std::min)(fragmentSize, remain);
+                receiver.Feed(p, size);
+                p += size;
+                remain -= size;
+            }
+            Assert::IsTrue(std::equal(std::begin(packet.data), std::end(packet.data), actual.begin(), actual.end()));
+        }
+
+        //2つの受信バッファーの境界をまたぐ形で2つ目パケットが存在する
+        TEST_METHOD(SplitHeaderPacket)
+        {
+            auto packet1 = CreatePacket<5>(L"ABCDE");
+            auto packet2 = CreatePacket<5>(L"FGHIJ");
+
+            auto expected = std::vector<std::wstring>{
+                std::wstring(std::begin(packet1.data), std::end(packet1.data)),
+                std::wstring(std::begin(packet2.data), std::end(packet2.data)),
+            };
+
+
+            auto totalSize = packet1.size + packet2.size;
+            auto buffer = std::make_unique<BYTE[]>(totalSize);
+            memcpy(&buffer[0], &packet1.p, packet1.size);
+            memcpy(&buffer[packet1.size], &packet2.p, packet2.size);
+
+            std::vector<std::wstring> acutals;
+            Receiver receiver(1024, [&](const auto p, auto s) {
+                acutals.emplace_back(std::wstring(reinterpret_cast<LPCWSTR>(p), 0, s / sizeof(WCHAR)));
+            });
+
+            const BYTE* p = &buffer[0];
+            DWORD remain = totalSize;
+            receiver.Feed(p, 16); p += 16; remain -= 16;
+            receiver.Feed(p, 1);  p += 1; remain -= 1;
+            receiver.Feed(p, remain);
+
+            Assert::IsTrue(std::equal(expected.begin(), expected.end(), acutals.begin(), acutals.end()));
+        }
+
+        //Receiverのステータス全パターンを網羅するテスト
+        TEST_METHOD(ComplexPackets)
+        {
+            auto packet1 = CreatePacket<5>(L"ABCDE");
+            auto packet2 = CreatePacket<10>(L"FGHIJKLMNO");
+            auto packet3 = CreatePacket<2>(L"PQ");
+            auto packet4 = CreatePacket<2>(L"RS");
+            auto packet5 = CreatePacket<7>(L"TUVWXYZ");
+
+            auto expected = std::vector<std::wstring>{
+                std::wstring(std::begin(packet1.data), std::end(packet1.data)),
+                std::wstring(std::begin(packet2.data), std::end(packet2.data)),
+                std::wstring(std::begin(packet3.data), std::end(packet3.data)),
+                std::wstring(std::begin(packet4.data), std::end(packet4.data)),
+                std::wstring(std::begin(packet5.data), std::end(packet5.data)),
+            };
+
+
+            auto totalSize = packet1.size + packet2.size + packet3.size + packet4.size + packet5.size;
+            auto buffer = std::make_unique<BYTE[]>(totalSize);
+            auto p = &buffer[0];
+            memcpy(p, &packet1.p, packet1.size); p += packet1.size;
+            memcpy(p, &packet2.p, packet2.size); p += packet2.size;
+            memcpy(p, &packet3.p, packet3.size); p += packet3.size;
+            memcpy(p, &packet4.p, packet4.size); p += packet4.size;
+            memcpy(p, &packet5.p, packet5.size);
+
+            std::vector<std::wstring> acutals;
+            Receiver receiver(1024, [&](const auto p, auto s) {
+                acutals.emplace_back(std::wstring(reinterpret_cast<LPCWSTR>(p), 0, s / sizeof(WCHAR)));
+            });
+
+            constexpr DWORD FEED_SIZE = 16;
+            auto remain = static_cast<DWORD>(totalSize);
+            p = &buffer[0];
+            while (remain > 0) {
+                auto size = (std::min)(remain, FEED_SIZE);
+                receiver.Feed(p, size);
+                remain -= size;
+                p += size;
+            }
+
+            Assert::IsTrue(std::equal(expected.begin(), expected.end(), acutals.begin(), acutals.end()));
+        }
+
+        //バッファーサイズが上限より大きい場合に例外
+        TEST_METHOD(TooLongPacket)
+        {
+            auto packet = CreatePacket<10>(L"FGHIJKLMNO");
+            Receiver receiver(4, [&](const auto p, auto s) {
+                Assert::Fail();
+            });
+
+            Assert::ExpectException<std::length_error>([&]() {receiver.Feed(&packet, packet.size); });
+        }
+
+    };
+}

--- a/TestSimplePipe/pch.h
+++ b/TestSimplePipe/pch.h
@@ -8,5 +8,8 @@
 #define PCH_H
 
 // プリコンパイルするヘッダーをここに追加します
+#pragma once
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
 
 #endif //PCH_H

--- a/inc/SimpleNamedPipe.h
+++ b/inc/SimpleNamedPipe.h
@@ -22,6 +22,7 @@ namespace abt::comm::simple_pipe
         BYTE data[1];
     };
 
+#pragma region Receiver
     /// <summary>
     /// 受信データ復号クラス
     /// </summary>
@@ -276,10 +277,10 @@ namespace abt::comm::simple_pipe
             state = &idle;
         }
     };
-
+#pragma endregion
 
     //バッファーサイズ
-    constexpr DWORD TYPICAL_BUFFER_SIZE = 2048;
+    constexpr DWORD TYPICAL_BUFFER_SIZE = 64 * 1024;
 
     /// <summary>
     /// イベント種別
@@ -330,9 +331,21 @@ namespace abt::comm::simple_pipe
         std::unique_ptr<BYTE[]> writeBuffer;
         //送信バッファー利用可イベント
         std::unique_ptr<concurrency::event> writableEvent;
+        //クローズ中フラグ
+        bool closing;
+
+        struct Defer {
+            std::function<void(void)> func;
+            Defer(std::function<void(void)> func) : func(func) {}
+            ~Defer() { if (func) func(); }
+            void Detach() { func = std::function<void(void)>(); }
+        };
 
     public:
-        static const DWORD BUFFER_SIZE = BUF_SIZE;
+        //送信・受信バッファーサイズ
+        inline static constexpr DWORD BUFFER_SIZE = BUF_SIZE;
+        //1回の送信・受信の最大サイズ
+        inline static constexpr DWORD MAX_DATA_SIZE = BUFFER_SIZE - static_cast<DWORD>(sizeof DWORD);
 
         SimpleNamedPipeBase() = default;
         SimpleNamedPipeBase(SimpleNamedPipeBase&&) = default;
@@ -353,6 +366,7 @@ namespace abt::comm::simple_pipe
             , receiver(std::make_unique<Receiver>(BUF_SIZE, receivedCallback))
             , writeBuffer(std::make_unique<BYTE[]>(BUF_SIZE))
             , writableEvent(std::make_unique<concurrency::event>())
+            , closing(false)
         {
             if constexpr(BUF_SIZE <= sizeof(Packet::size)) {
                 throw std::runtime_error("BUF_SIZE is too short");
@@ -399,7 +413,11 @@ namespace abt::comm::simple_pipe
             }
             if (ERROR_IO_PENDING != lastErr) {
                 //I/O完了待ち以外ではエラー
-                winrt::throw_last_error();
+                if (!closing) {
+                    winrt::throw_last_error();
+                }
+                //クローズ中は例外を送出せずに切断状態を返す
+                return false;
             }
             return true;
         }
@@ -421,8 +439,11 @@ namespace abt::comm::simple_pipe
                     //切断状態
                     return false;
                 }
-                //エラー
-                winrt::throw_last_error();
+                //クローズ中のエラーは無視
+                if (!closing) {
+                    winrt::throw_last_error();
+                }
+                return false;
             }
             //データ受信
             receiver->Feed(readBuffer.get(), readSize);
@@ -444,12 +465,44 @@ namespace abt::comm::simple_pipe
             return connected;
         }
 
-        struct Defer {
-            std::function<void(void)> func;
-            Defer(std::function<void(void)> func) : func(func) {}
-            ~Defer() { if(func) func(); }
-            void Detach() { func = std::function<void(void)>(); }
-        };
+        /// <summary>
+        /// 書き込み完了待ち
+        /// </summary>
+        /// <param name="aquireLock">true:完了時点で書き込みロックを取得</param>
+        /// <param name="ct">キャンセルトークン</param>
+        /// <param name="timeout">タイムアウト(defalut:タイムアウトしない)</param>
+        /// <returns>非同期オブジェクト</returns>
+        concurrency::task<void> WaitWriteComplete(bool aquireLock, concurrency::cancellation_token ct, unsigned int timeout = concurrency::COOPERATIVE_TIMEOUT_INFINITE)
+        {
+            return concurrency::create_task([this, aquireLock, timeout, ct] {
+                std::vector<concurrency::event*> events;
+                concurrency::event cancelEvent;
+                if (ct.is_cancelable()) {
+                    concurrency::cancellation_token_registration cookie;
+                    cookie = ct.register_callback([&cancelEvent, ct, &cookie]() {
+                        cancelEvent.set();
+                        ct.deregister_callback(cookie);
+                    });
+                    events.emplace_back(&cancelEvent);
+                }
+                events.emplace_back(writableEvent.get());
+                auto res = concurrency::event::wait_for_multiple(&events[0], events.size(), false, timeout);
+                if (concurrency::COOPERATIVE_WAIT_TIMEOUT == res) {
+                    //タイムアウト
+                    throw concurrency::task_canceled("timeout");
+                }
+                if (0 <= res && res < events.size()) {
+                    if (events[res] == &cancelEvent) {
+                        concurrency::cancel_current_task();
+                    }
+                    if (events[res] == writableEvent.get()) {
+                        if (aquireLock) {
+                            writableEvent->reset();
+                        }
+                    }
+                }
+            }, concurrency::task_options(ct));
+        }
 
         /// <summary>
         /// 非同期送信処理
@@ -458,22 +511,23 @@ namespace abt::comm::simple_pipe
         /// <param name="size">送信サイズ</param>
         /// <param name="ct">キャンセルトークン</param>
         /// <returns>非同期タスク</returns>
-        concurrency::task<void> WriteAsync(LPCVOID buffer, size_t size, concurrency::cancellation_token ct)
+        concurrency::task<void> WriteAsync(LPCVOID buffer, size_t size, concurrency::cancellation_token ct = concurrency::cancellation_token::none())
         {
             if (!static_cast<bool>(handlePipe)) {
                 //handleが無効
                 throw std::runtime_error("this instance is invalid");
             }
 
-            if (size > BUF_SIZE - sizeof(Packet::size) ) {
-                //バッファーサイズより大きい場合はエラー
+            if (size > MAX_DATA_SIZE ) {
                 throw std::length_error("size is too long");
             }
 
-            //書き込み中ならば待ち
-            writableEvent->wait();
-            //書込み可能イベントリセット
-            writableEvent->reset();
+            if (ct.is_canceled()) {
+                throw concurrency::task_canceled();
+            }
+
+            //書き込み中ならば書き込み完了まで待って書き込みロックを取得
+            WaitWriteComplete(true, ct).wait();
             //同期的に書き込み完了した際にイベントセットする
             Defer defer([this] {if(this->writableEvent) this->writableEvent->set(); });
 
@@ -518,7 +572,7 @@ namespace abt::comm::simple_pipe
                     winrt::check_bool(static_cast<bool>(cancelEvent));
                     concurrency::cancellation_token_registration cookie;
                     cookie = ct.register_callback([&cancelEvent, ct, &cookie]() {
-                        SetEvent(cancelEvent.get());
+                        winrt::check_bool(SetEvent(cancelEvent.get()));
                         ct.deregister_callback(cookie);
                         });
                     handles.emplace_back(cancelEvent.get());
@@ -530,13 +584,18 @@ namespace abt::comm::simple_pipe
                 auto index = res - WAIT_OBJECT_0;
                 if (0 <= index && index < handles.size()) {
                     //書き込み完了、もしくはキャンセル
-                    ResetEvent(handles[index]);
+                    winrt::check_bool(ResetEvent(handles[index]));
+                    if (handles[index] == cancelEvent.get()) {
+                        //タスクキャンセル処理
+                        concurrency::cancel_current_task();
+                    }
                 }
             }, concurrency::task_options(ct));
         }
 
         void Close()
         {
+            closing = true;
             if (static_cast<bool>(handlePipe)) {
                 handlePipe.close();
             }
@@ -550,15 +609,17 @@ namespace abt::comm::simple_pipe
     class SimpleNamedPipeServer
     {
     public:
-        static constexpr DWORD BUFFER_SIZE = BUF_SIZE;
+        using Base = SimpleNamedPipeBase<BUF_SIZE>;
+        inline static constexpr DWORD BUFFER_SIZE = Base::BUFFER_SIZE;
+        inline static constexpr DWORD MAX_DATA_SIZE = Base::MAX_DATA_SIZE;
         using Callback = std::function<void(SimpleNamedPipeServer<BUF_SIZE>&, const PipeEventParam&)>;
     private:
-        using Base = SimpleNamedPipeBase<BUF_SIZE>;
         Base base;
 
         Callback callback;
         OVERLAPPED connectionOverlap;
         winrt::handle connectionEvent;
+        winrt::handle stopEvent;
         concurrency::task<void> watcherTask;
 
         void Received(LPCVOID buffer, size_t size)
@@ -575,7 +636,7 @@ namespace abt::comm::simple_pipe
             return concurrency::create_task([this]() {
                 while (true) {
                     //接続、受信イベントを監視
-                    const HANDLE handles[]{ connectionEvent.get(), base.ReadEvent().get() };
+                    const HANDLE handles[]{ stopEvent.get(), connectionEvent.get(), base.ReadEvent().get() };
                     auto res = WaitForMultipleObjects(_countof(handles), handles, false, INFINITE);
                     if (res == WAIT_FAILED) {
                         //エラー
@@ -588,8 +649,11 @@ namespace abt::comm::simple_pipe
                     auto index = res - WAIT_OBJECT_0;
                     if (0 <= index && index < _countof(handles)) {
                         bool connected = false;
-                        ResetEvent(handles[index]);
-                        if (connectionEvent.get() == handles[index]) {
+                        winrt::check_bool(ResetEvent(handles[index]));
+                        if (stopEvent.get() == handles[index]) {
+                            //停止イベント
+                            break;
+                        } else if (connectionEvent.get() == handles[index]) {
                             //非同期受信処理開始
                             connected = base.OverappedRead();
                             //接続イベント
@@ -604,6 +668,7 @@ namespace abt::comm::simple_pipe
                             //切断コールバック
                             callback(*this, PipeEventParam{ PipeEventType::DISCONNECTED, nullptr, 0 });
                             //終了した接続の後始末をして次回接続の待機
+                            FlushFileBuffers(base.Handle());
                             winrt::check_bool(DisconnectNamedPipe(base.Handle()));
                             BeginConnect();
                         }
@@ -668,7 +733,7 @@ namespace abt::comm::simple_pipe
                 CreateNamedPipeW(
                     name,
                     PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
-                    PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_REJECT_REMOTE_CLIENTS,
+                    PIPE_TYPE_BYTE | PIPE_REJECT_REMOTE_CLIENTS,
                     1,
                     BUF_SIZE,
                     BUF_SIZE,
@@ -687,6 +752,10 @@ namespace abt::comm::simple_pipe
             //接続用オーバーラップ構造体の初期化
             connectionOverlap.hEvent = connectionEvent.get();
 
+            //停止イベント作成
+            stopEvent = winrt::handle{ CreateEventW(nullptr, true, false, nullptr) };
+            winrt::check_bool(static_cast<bool>(stopEvent));
+
             //接続待ち開始
             BeginConnect();
 
@@ -703,7 +772,7 @@ namespace abt::comm::simple_pipe
                 });
         }
 
-        concurrency::task<void> WriteAsync(LPCVOID buffer, size_t size, concurrency::cancellation_token ct)
+        concurrency::task<void> WriteAsync(LPCVOID buffer, size_t size, concurrency::cancellation_token ct = concurrency::cancellation_token::none())
         {
             return base.WriteAsync(buffer, size, ct);
         }
@@ -715,11 +784,15 @@ namespace abt::comm::simple_pipe
 
         void Close()
         {
+            winrt::check_bool(SetEvent(stopEvent.get()));
             base.Close();
         }
 
         virtual ~SimpleNamedPipeServer()
         {
+            Close();
+            try { watcherTask.wait(); }
+            catch (...) {};
         }
     };
 
@@ -732,10 +805,11 @@ namespace abt::comm::simple_pipe
     class SimpleNamedPipeClient
     {
     public:
-        static constexpr DWORD BUFFER_SIZE = BUF_SIZE;
+        using Base = SimpleNamedPipeBase<BUF_SIZE>;
+        inline static constexpr DWORD BUFFER_SIZE = Base::BUFFER_SIZE;
+        inline static constexpr DWORD MAX_DATA_SIZE = Base::MAX_DATA_SIZE;
         using Callback = std::function<void(SimpleNamedPipeClient<BUF_SIZE>&, const PipeEventParam&)>;
     private:
-        using Base = SimpleNamedPipeBase<BUF_SIZE>;
         Base base;
 
         Callback callback;
@@ -766,12 +840,13 @@ namespace abt::comm::simple_pipe
                     }
                     auto index = res - WAIT_OBJECT_0;
                     if (0 <= index && index < _countof(handles)) {
-                        ResetEvent(handles[index]);
+                        winrt::check_bool(ResetEvent(handles[index]));
                         if (base.ReadEvent().get() == handles[index]) {
                             //読み込みイベント
                             if (!base.OnSignalRead()) {
                                 //切断状態の場合
                                 callback(*this, PipeEventParam{ PipeEventType::DISCONNECTED, nullptr, 0 });
+                                break;
                             }
                         }
                     }
@@ -804,6 +879,7 @@ namespace abt::comm::simple_pipe
         SimpleNamedPipeClient(LPCWSTR name, Callback callback)
             : callback(callback)
         {
+            winrt::check_bool(WaitNamedPipe(name, NMPWAIT_USE_DEFAULT_WAIT));
             //サーバーへ接続
             winrt::file_handle handlePipe(CreateFileW(
                 name,
@@ -820,6 +896,9 @@ namespace abt::comm::simple_pipe
             //ベース処理の以上用クラスを作成
             base = Base(std::move(handlePipe), std::bind(&SimpleNamedPipeClient::Received, this, std::placeholders::_1, std::placeholders::_2));
 
+            //非同期受信処理開始
+            base.OverappedRead();
+
             //監視タスク開始
             watcherTask = WatchAsync().then([this](concurrency::task<void> prevTask) {
                 try {
@@ -831,11 +910,9 @@ namespace abt::comm::simple_pipe
                     this->callback(*this, PipeEventParam{ PipeEventType::EXCEPTION, nullptr, 0, prevTask });
                 }
                 });
-            //非同期受信処理開始
-            base.OverappedRead();
         }
 
-        concurrency::task<void> WriteAsync(LPCVOID buffer, size_t size, concurrency::cancellation_token ct)
+        concurrency::task<void> WriteAsync(LPCVOID buffer, size_t size, concurrency::cancellation_token ct = concurrency::cancellation_token::none())
         {
             return base.WriteAsync(buffer, size, ct);
         }
@@ -847,11 +924,16 @@ namespace abt::comm::simple_pipe
 
         void Close()
         {
+            FlushFileBuffers(base.Handle());
             base.Close();
         }
 
         virtual ~SimpleNamedPipeClient()
         {
+            //監視タスク終了待ち（例外は無視）
+            Close();
+            try { watcherTask.wait();}
+            catch (...) {};
         }
     };
 

--- a/inc/SimpleNamedPipe.h
+++ b/inc/SimpleNamedPipe.h
@@ -369,7 +369,7 @@ namespace abt::comm::simple_pipe
             , closing(false)
         {
             if constexpr(BUF_SIZE <= sizeof(Packet::size)) {
-                throw std::runtime_error("BUF_SIZE is too short");
+                throw std::invalid_argument("BUF_SIZE is too short");
             }
             readEvent = winrt::handle{ CreateEventW(nullptr, true, false, nullptr) };
             winrt::check_bool(static_cast<bool>(readEvent));

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Windowsのサービスと通常アプリケーションとのあいだのプロ�
 * Windows10 以降に対応。レガシー環境は考慮していない。
 * *winrt*, *ppl* に依存。
 * 非同期処理に対応。というか、非同期オンリー。
-* 1件あたり数KBの少量のデータ通信を想定している。
+* 1件あたり数十KBの少量のデータ通信を想定している。（推奨サイズは64KB）
 
 # 使い方
 ヘッダーファイル `SimpleNamedPipe.h` をinclude する。
@@ -64,7 +64,7 @@ SimpleNamedPipeServer<4096> pipeServer(PIPE_NAME, nullptr, [&](auto& ps, const a
 ## クライアント
 `SimpleNamedPipeClient<BUF_SIZE>` でクライアントインスタンスを生成する。
 
-`BUF_SIZE` は通信パケットサイズを指定する。ヘッダー領域として4byte消費するので、4より大きい値を指定すること。4以下の場合は `std::runtime_error` が発生する。
+`BUF_SIZE` は通信パケットサイズを指定する。ヘッダー領域として4byte消費するので、4より大きい値を指定すること。4以下の場合は `std::invalid_argument` が発生する。
 
 上記の通り4byteをヘッダー領域として利用するため、実際に利用可能なサイズは `BUF_SIZE - 4byte` となる。
 


### PR DESCRIPTION
 - サーバー、クライアント接続の単体テストを追加
 - Close実行後のINVALUD_HANDLE等のエラーは無視する
 - クライアントがデストラクト時に切断を認識でない問題を修正
 - TYPICAL_BUFFER_SIZEを64KBに変更
 - パイプ初期化パラメータをバイトストリームに変更