### PR TITLE
送信データサイズ制限を緩和

### DIFF
--- a/SimplePipe/main.cpp
+++ b/SimplePipe/main.cpp
@@ -85,7 +85,7 @@ int main()
         //例外の詳細はex.code() でHRESULT型に変換されたWindowsシステムエラーコードを取得する
         // エラーコードの詳細は以下のページを参照
         // https://learn.microsoft.com/en-us/windows/win32/api/winerror/nf-winerror-hresult_from_win32
-        // https://learn.microsoft.com/ja-jp/windows/win32/debug/system-error-codes--0-499-
+        // https://learn.microsoft.com/ja-jp/windows/win32/debug/system-error-codes#system-error-codes
         if (ex.code() == HRESULT_FROM_WIN32(ERROR_PIPE_BUSY)) {
             std::wcerr << L"既に実行中のサーバーが存在します: " << PIPE_NAME << std::endl;
         }

--- a/SimplePipeClient/main.cpp
+++ b/SimplePipeClient/main.cpp
@@ -85,7 +85,7 @@ int main()
         //例外の詳細はex.code() でHRESULT型に変換されたWindowsシステムエラーコードを取得する
         // エラーコードの詳細は以下のページを参照
         // https://learn.microsoft.com/en-us/windows/win32/api/winerror/nf-winerror-hresult_from_win32
-        // https://learn.microsoft.com/ja-jp/windows/win32/debug/system-error-codes--0-499-
+        // https://learn.microsoft.com/ja-jp/windows/win32/debug/system-error-codes#system-error-codes
         if (ex.code() == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)) {
             //サーバーとなるpipeが存在しない
             std::wcerr << L"接続先が存在しません: " << PIPE_NAME << std::endl;

--- a/TestSimplePipe/TestSimplePipe.cpp
+++ b/TestSimplePipe/TestSimplePipe.cpp
@@ -1,9 +1,11 @@
 ﻿#include "pch.h"
+#include <random>
 #include <windows.h>
 #include <string>
 #include <sstream>
 #include <memory>
 #include <numeric>
+#include <limits>
 #include <algorithm>
 #include <memory.h>
 #include <ppl.h>
@@ -24,10 +26,10 @@ namespace abt::comm::simple_pipe::test
         TEST_METHOD(Constants)
         {
             Assert::AreEqual(TypicalSimpleNamedPipeServer::BUFFER_SIZE, TYPICAL_BUFFER_SIZE);
-            Assert::AreEqual(TypicalSimpleNamedPipeServer::MAX_DATA_SIZE, TYPICAL_BUFFER_SIZE - static_cast<DWORD>(sizeof DWORD));
+            Assert::AreEqual(TypicalSimpleNamedPipeServer::MAX_DATA_SIZE, static_cast<size_t>((std::numeric_limits<DWORD>::max)() - static_cast<DWORD>(sizeof DWORD)));
 
             Assert::AreEqual(TypicalSimpleNamedPipeClient::BUFFER_SIZE, TYPICAL_BUFFER_SIZE);
-            Assert::AreEqual(TypicalSimpleNamedPipeClient::MAX_DATA_SIZE, TYPICAL_BUFFER_SIZE - static_cast<DWORD>(sizeof DWORD));
+            Assert::AreEqual(TypicalSimpleNamedPipeClient::MAX_DATA_SIZE, static_cast<size_t>((std::numeric_limits<DWORD>::max)() - static_cast<DWORD>(sizeof DWORD)));
         }
 
         TEST_METHOD(HelloEcho)
@@ -36,7 +38,7 @@ namespace abt::comm::simple_pipe::test
 
             concurrency::task<void> serverErrTask = concurrency::task_from_result();
             concurrency::event closedEvent;
-            
+
             TypicalSimpleNamedPipeServer server(pipeName.c_str(), nullptr, [&](auto& ps, const auto& param) {
                 switch (param.type) {
                 case PipeEventType::CONNECTED:
@@ -62,6 +64,8 @@ namespace abt::comm::simple_pipe::test
                 }
             });
 
+            Assert::AreEqual(static_cast<std::wstring_view>(pipeName), static_cast<std::wstring_view>(server.PipeName()));
+
             concurrency::task<void> clientErrTask = concurrency::task_from_result();
             concurrency::event echoComplete;
             std::wstring echoMessage;
@@ -85,6 +89,7 @@ namespace abt::comm::simple_pipe::test
                     break;
                 }
             });
+            Assert::AreEqual(static_cast<std::wstring_view>(pipeName), static_cast<std::wstring_view>(client.PipeName()));
 
             WCHAR hello[] = L"HELLO WORLD!";
 
@@ -168,13 +173,13 @@ namespace abt::comm::simple_pipe::test
 
 
             std::vector<std::wstring> expectedValues;
-            for (int i = 0; i < repeat; ++i) {
+            for (auto i = 0ul; i < repeat; ++i) {
                 std::wstringstream oss;
                 oss << L"HELLO WORLD![" << i << "]";
                 auto message = oss.str();
                 expectedValues.emplace_back(std::wstring(L"echo: ") + message);
 
-                client.WriteAsync(&message[0], message.size() * sizeof(WCHAR));
+                client.WriteAsync(&message[0], message.size() * sizeof(WCHAR)).wait();
 
             }
 
@@ -242,7 +247,7 @@ namespace abt::comm::simple_pipe::test
             concurrency::task<void> clientErrTask = concurrency::task_from_result();
             concurrency::event echoComplete;
             std::wstring echoMessage;
-            for (auto i = 0; i < repeat; ++i) {
+            for (auto i = 0ul; i < repeat; ++i) {
                 TypicalSimpleNamedPipeClient client(pipeName.c_str(), [&](auto& ps, const auto& param) {
                     switch (param.type) {
                     case PipeEventType::DISCONNECTED:
@@ -442,6 +447,87 @@ namespace abt::comm::simple_pipe::test
             concurrency::task<void> serverErrTask = concurrency::task_from_result();
             concurrency::event closedEvent;
 
+            constexpr size_t BUFFER_SIZE = 512;
+
+            SimpleNamedPipeServer<BUFFER_SIZE> server(pipeName.c_str(), nullptr, [&](auto& ps, const auto& param) {
+                switch (param.type) {
+                case PipeEventType::CONNECTED:
+                    break;
+                case PipeEventType::DISCONNECTED:
+                    closedEvent.set();
+                    break;
+                case PipeEventType::RECEIVED:
+                    ps.WriteAsync(param.readBuffer, param.readedSize).wait();
+                    break;
+                case PipeEventType::EXCEPTION:
+                    //監視タスクで例外発生
+                    if (param.errTask) {
+                        serverErrTask = param.errTask.value();
+                    }
+                    break;
+                }
+            });
+
+            concurrency::task<void> clientErrTask = concurrency::task_from_result();
+            concurrency::event echoComplete;
+            std::wstring echoMessage;
+
+            SimpleNamedPipeClient<BUFFER_SIZE> client(pipeName.c_str(), [&](auto& ps, const auto& param) {
+                switch (param.type) {
+                case PipeEventType::DISCONNECTED:
+                    break;
+                case PipeEventType::RECEIVED:
+                {
+                    std::wstring m(reinterpret_cast<LPCWSTR>(param.readBuffer), 0, param.readedSize / sizeof(WCHAR));
+                    echoMessage = m;
+                    echoComplete.set();
+                }
+                break;
+                case PipeEventType::EXCEPTION:
+                    //監視タスクで例外発生
+                    if (param.errTask) {
+                        clientErrTask = param.errTask.value();
+                    }
+                    break;
+                }
+            });
+
+            constexpr size_t SAMPLE_SIZE = BUFFER_SIZE * 8;
+            constexpr size_t SAMPLE_BYTE_SIZE = SAMPLE_SIZE * sizeof(int);
+            auto expected = std::make_unique<int[]>(SAMPLE_SIZE);
+            for (int i = 0; i < SAMPLE_SIZE; ++i) {
+                expected[i] = std::rand();
+            }
+
+            {
+                auto cts = concurrency::cancellation_token_source();
+                cts.cancel();
+                Assert::ExpectException<concurrency::task_canceled>([&]() {
+                    client.WriteAsync(&expected[0], SAMPLE_BYTE_SIZE, cts.get_token()).get();
+                });
+            }
+
+            if (concurrency::COOPERATIVE_TIMEOUT_INFINITE == echoComplete.wait(1000)) {
+                Assert::Fail();
+            }
+
+            client.Close();
+            if (concurrency::COOPERATIVE_TIMEOUT_INFINITE == closedEvent.wait(1000)) {
+                Assert::Fail();
+            }
+            server.Close();
+
+            serverErrTask.wait();
+            clientErrTask.wait();
+        }
+
+        TEST_METHOD(TooLongWriteSize)
+        {
+            auto pipeName = std::wstring(L"\\\\.\\pipe\\") + winrt::to_hstring(winrt::Windows::Foundation::GuidHelper::CreateNewGuid());
+
+            concurrency::task<void> serverErrTask = concurrency::task_from_result();
+            concurrency::event closedEvent;
+
             TypicalSimpleNamedPipeServer server(pipeName.c_str(), nullptr, [&](auto& ps, const auto& param) {
                 switch (param.type) {
                 case PipeEventType::CONNECTED:
@@ -491,23 +577,99 @@ namespace abt::comm::simple_pipe::test
                 }
             });
 
-            WCHAR hello[] = L"HELLO WORLD!";
+            WCHAR dummy[] = L"DUMMY";
 
-            auto cts = concurrency::cancellation_token_source();
-            cts.cancel();
-            Assert::ExpectException<concurrency::task_canceled>([&]() {
-                client.WriteAsync(&hello[0], sizeof(hello), cts.get_token());
+            Assert::ExpectException<std::length_error>([&]() {
+                client.WriteAsync(&dummy[0], client.MAX_DATA_SIZE + 1).wait();
+            });
+        }
+
+        TEST_METHOD(OverbufferTransfer)
+        {
+            auto pipeName = std::wstring(L"\\\\.\\pipe\\") + winrt::to_hstring(winrt::Windows::Foundation::GuidHelper::CreateNewGuid());
+
+            concurrency::task<void> serverErrTask = concurrency::task_from_result();
+            concurrency::event closedEvent;
+
+            constexpr size_t BUFFER_SIZE = 1024;
+            constexpr size_t SAMPLE_SIZE = 4 * 1024;
+            auto expected = std::make_unique<int[]>(SAMPLE_SIZE);
+            for (int i = 0; i < SAMPLE_SIZE; ++i) {
+                expected[i] = std::rand();
+            }
+
+            SimpleNamedPipeServer<BUFFER_SIZE> server(pipeName.c_str(), nullptr, [&](auto& ps, const auto& param) {
+                switch (param.type) {
+                case PipeEventType::CONNECTED:
+                    break;
+                case PipeEventType::DISCONNECTED:
+                    closedEvent.set();
+                    break;
+                case PipeEventType::RECEIVED:
+                {
+                    //そのままか返す
+                    ps.WriteAsync(param.readBuffer, param.readedSize).wait();
+                }
+                break;
+                case PipeEventType::EXCEPTION:
+                    //監視タスクで例外発生
+                    if (param.errTask) {
+                        serverErrTask = param.errTask.value();
+                    }
+                    break;
+                }
             });
 
+            Assert::AreEqual(static_cast<std::wstring_view>(pipeName), static_cast<std::wstring_view>(server.PipeName()));
+
+            concurrency::task<void> clientErrTask = concurrency::task_from_result();
+            concurrency::event echoComplete;
+
+            auto actual = std::make_unique<int[]>(SAMPLE_SIZE);
+            constexpr size_t SAMPLE_BYTE_SIZE = SAMPLE_SIZE * sizeof(int);
+
+            SimpleNamedPipeClient<BUFFER_SIZE> client(pipeName.c_str(), [&](auto& ps, const auto& param) {
+                switch (param.type) {
+                case PipeEventType::DISCONNECTED:
+                    break;
+                case PipeEventType::RECEIVED:
+                {
+                    if (param.readedSize == SAMPLE_BYTE_SIZE) {
+                        memcpy(&actual[0], param.readBuffer, param.readedSize);
+                        echoComplete.set();
+                    }
+                }
+                break;
+                case PipeEventType::EXCEPTION:
+                    //監視タスクで例外発生
+                    if (param.errTask) {
+                        clientErrTask = param.errTask.value();
+                    }
+                    break;
+                }
+            });
+            client.WriteAsync(&expected[0], SAMPLE_BYTE_SIZE).wait();
             if (concurrency::COOPERATIVE_TIMEOUT_INFINITE == echoComplete.wait(1000)) {
                 Assert::Fail();
             }
+            Assert::AreEqual(0, memcmp(&expected[0], &actual[0], SAMPLE_BYTE_SIZE));
+
+            echoComplete.reset();
+
+            //もう1回
+            for (int i = 0; i < SAMPLE_SIZE; ++i) {
+                expected[i] = std::rand();
+            }
+            client.WriteAsync(&expected[0], SAMPLE_BYTE_SIZE).wait();
+            if (concurrency::COOPERATIVE_TIMEOUT_INFINITE == echoComplete.wait(1000)) {
+                Assert::Fail();
+            }
+            Assert::AreEqual(0, memcmp(&expected[0], &actual[0], SAMPLE_BYTE_SIZE));
 
             client.Close();
             if (concurrency::COOPERATIVE_TIMEOUT_INFINITE == closedEvent.wait(1000)) {
                 Assert::Fail();
             }
-            server.Close();
 
             serverErrTask.wait();
             clientErrTask.wait();

--- a/TestSimplePipe/TestSimplePipeReceiver.cpp
+++ b/TestSimplePipe/TestSimplePipeReceiver.cpp
@@ -190,17 +190,5 @@ namespace abt::comm::simple_pipe::test::receiver
 
             Assert::IsTrue(std::equal(expected.begin(), expected.end(), acutals.begin(), acutals.end()));
         }
-
-        //バッファーサイズが上限より大きい場合に例外
-        TEST_METHOD(TooLongPacket)
-        {
-            auto packet = CreatePacket<10>(L"FGHIJKLMNO");
-            Receiver receiver(4, [&](const auto p, auto s) {
-                Assert::Fail();
-            });
-
-            Assert::ExpectException<std::length_error>([&]() {receiver.Feed(&packet, packet.size); });
-        }
-
     };
 }


### PR DESCRIPTION
送信データサイズ制限を緩和し、uint32t - 4 まで可能ないように修正。BUF_SIZEは内部バッファーサイズの設定のみに使用する。

 - 送信データは送信完了まで呼び出し側の責任で維持する必要がある。
