### PR TITLE
接続から即切断した場合に切断イベントが発行されない問題を修正

### DIFF
--- a/tool/ContinuousTest.ps1
+++ b/tool/ContinuousTest.ps1
@@ -1,0 +1,19 @@
+﻿# 指定回数単体テストを繰り返す。エラーとなったら停止。
+# 無指定時は100回
+# 開発ツールチェインに実行パスが設定されていること
+
+$cnt = 100
+try {
+    if($args[0]){
+        $cnt = [int]$args[0]
+    }
+}
+catch {}
+
+1..$cnt | Foreach-object {
+    vstest.console.exe .\x64\Release\TestSimplePipe.dll /TestCaseFilter:Priority!=2 /Parallel
+    echo $_
+    if(!$?){
+        break
+    }
+}


### PR DESCRIPTION
 - Clientのコンストラクタでのチェックを追加
 - 不要なハンドルチェックを削除
 - 切断時のエラーチェックを強化